### PR TITLE
indented example

### DIFF
--- a/docs/scan-using-snyk/policies/the-.snyk-file.md
+++ b/docs/scan-using-snyk/policies/the-.snyk-file.md
@@ -64,8 +64,8 @@ The `ignore:` is an ignore rule in the form of:
 ignore:
   snyk-vulnid:
     - path to library using > seperator :
-      reason: 'text string'
-      expires: 'datetime string'
+        reason: 'text string'
+        expires: 'datetime string'
 ```
 
 The `patch`: is in the form of:


### PR DESCRIPTION
The reason does not appear to be consumed when at the same level as the path. The values are non-existent in the json output.